### PR TITLE
Exclude coveralls on JRuby

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,10 @@
 require 'simplecov'
-require 'coveralls'
-require 'pry'
 
 ENV['RACK_ENV'] = 'test'
 
+SimpleCov.formatter = Coveralls::SimpleCov::Formatter if defined?(Coveralls)
+
 # Configure code coverage reporting
-SimpleCov.formatter = Coveralls::SimpleCov::Formatter
 SimpleCov.start do
   add_filter '/spec/'
   coverage_dir 'docs/coverage'

--- a/versions.rb.gemspec
+++ b/versions.rb.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '> 1.8'
 
-  s.add_development_dependency 'coveralls', '~> 0.7.0'
+  s.add_development_dependency 'coveralls', '~> 0.7.0' unless RUBY_PLATFORM =~ /java/
   s.add_development_dependency 'pry',       '~> 0.9.12.6'
   s.add_development_dependency 'rr',        '~> 1.1.2'
   s.add_development_dependency 'rspec',     '~> 2.14.1'


### PR DESCRIPTION
The failing Travis tests are related to the Coveralls gem, it's not worth troubleshooting.
